### PR TITLE
Fix feature-label length mismatch

### DIFF
--- a/deteccao_anomalias.py
+++ b/deteccao_anomalias.py
@@ -164,7 +164,9 @@ def selecionar_features(df, base_name, colunas_base):
             features['Location'] = df[loc_col].astype('category').cat.codes
             break
 
-    return features.dropna()
+    # Preencher valores faltantes para manter o mesmo tamanho do dataset e
+    # evitar inconsistências de comprimento entre features e rótulos
+    return features.fillna(0)
 
 # =======================
 # CARGA DE DADOS E PRÉ-PROCESSAMENTO


### PR DESCRIPTION
## Summary
- avoid dropping rows when extracting features
- fill missing values with `0` to keep label and feature counts aligned

## Testing
- `pip install pandas` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6847980117a4832281f04636ac454acb